### PR TITLE
Implement seamless Ruby Array support for Cassandra List collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ result = session.query("SELECT * FROM system_schema.tables")
 session.close
 ```
 
+## Supported Data Types
+
+CassandraC supports all major Cassandra data types with seamless Ruby integration:
+
+### Scalar Types
+- **Text/VARCHAR/ASCII**: Regular Ruby strings with UTF-8 and ASCII validation
+- **Integers**: TinyInt, SmallInt, Int, BigInt, VarInt with overflow handling
+- **Floating Point**: Float, Double, Decimal with precision control
+- **Boolean**: Ruby true/false values
+- **UUID/TimeUUID**: Typed UUID objects with generation and time extraction
+- **Blob**: Binary data with proper encoding
+- **Inet**: IP address storage (IPv4/IPv6)
+
+### Collection Types
+- **Lists**: Plain Ruby Arrays work seamlessly with Cassandra `list<type>` columns
+
+```ruby
+# Arrays bind directly to list columns
+session.execute("INSERT INTO table (id, numbers, tags) VALUES (?, ?, ?)", 
+                [1, [1, 2, 3], ["ruby", "cassandra"]])
+
+# Results come back as Ruby Arrays  
+result = session.query("SELECT numbers, tags FROM table WHERE id = 1")
+numbers, tags = result.to_a.first  # [1, 2, 3], ["ruby", "cassandra"]
+```
+
+See [EXAMPLES.md](EXAMPLES.md) for comprehensive usage examples of all data types.
+
 ### Load Balancing Policies
 
 CassandraC supports different load balancing policies to control how queries are distributed to nodes in a Cassandra cluster.

--- a/TODO.md
+++ b/TODO.md
@@ -128,7 +128,7 @@ This document outlines all features and improvements needed to make CassandraC a
     - [x] Proper counter table schema requirements (non-counter columns in primary key)
   - [ ] Duration type
 - [ ] **Collection Types**:
-  - [ ] List collections
+  - [x] List collections
   - [ ] Set collections
   - [ ] Map collections
   - [ ] Frozen collections

--- a/ext/cassandra_c/cassandra_c.h
+++ b/ext/cassandra_c/cassandra_c.h
@@ -119,6 +119,8 @@ CassError ruby_value_to_cass_uuid(CassStatement* statement, size_t index, VALUE 
 CassError ruby_value_to_cass_uuid_by_name(CassStatement* statement, const char* name, VALUE rb_value);
 CassError ruby_value_to_cass_timeuuid(CassStatement* statement, size_t index, VALUE rb_value);
 CassError ruby_value_to_cass_timeuuid_by_name(CassStatement* statement, const char* name, VALUE rb_value);
+CassError ruby_value_to_cass_list(CassStatement* statement, size_t index, VALUE rb_value);
+CassError ruby_value_to_cass_list_by_name(CassStatement* statement, const char* name, VALUE rb_value);
 
 // ============================================================================
 // Module Initialization Functions

--- a/test/test_array_collection.rb
+++ b/test/test_array_collection.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestArrayCollection < Minitest::Test
+  def setup
+    # Clean up test table before each test
+    session.query("TRUNCATE cassandra_c_test.list_types")
+  end
+
+  def test_array_database_round_trip_strings
+    # Insert a list of strings
+    string_array = ["hello", "world", "test"]
+
+    statement = CassandraC::Native::Statement.new("INSERT INTO cassandra_c_test.list_types (id, string_list) VALUES (?, ?)", 2)
+    statement.bind_by_index(0, "string_test")
+    statement.bind_by_index(1, string_array)
+
+    result = session.execute(statement)
+    assert_instance_of CassandraC::Native::Result, result
+
+    # Retrieve and verify
+    query_result = session.query("SELECT string_list FROM cassandra_c_test.list_types WHERE id = 'string_test'")
+    row = query_result.to_a.first
+    retrieved_array = row[0]
+
+    assert_instance_of Array, retrieved_array
+    assert_equal ["hello", "world", "test"], retrieved_array
+  end
+
+  def test_array_database_round_trip_integers
+    # Insert a list of integers
+    int_array = [1, 2, 3, 42, 100]
+
+    statement = CassandraC::Native::Statement.new("INSERT INTO cassandra_c_test.list_types (id, int_list) VALUES (?, ?)", 2)
+    statement.bind_by_index(0, "int_test")
+    statement.bind_by_index(1, int_array)
+
+    result = session.execute(statement)
+    assert_instance_of CassandraC::Native::Result, result
+
+    # Retrieve and verify
+    query_result = session.query("SELECT int_list FROM cassandra_c_test.list_types WHERE id = 'int_test'")
+    row = query_result.to_a.first
+    retrieved_array = row[0]
+
+    assert_instance_of Array, retrieved_array
+    assert_equal [1, 2, 3, 42, 100], retrieved_array
+  end
+
+  def test_array_database_round_trip_strings_as_mixed
+    # Insert a list with values converted to strings (for mixed_list column)
+    # Note: Cassandra collections are strongly typed, so we convert everything to strings
+    mixed_array = ["string", "42", "3.14", "true", "false"]
+
+    statement = CassandraC::Native::Statement.new("INSERT INTO cassandra_c_test.list_types (id, mixed_list) VALUES (?, ?)", 2)
+    statement.bind_by_index(0, "mixed_test")
+    statement.bind_by_index(1, mixed_array)
+
+    result = session.execute(statement)
+    assert_instance_of CassandraC::Native::Result, result
+
+    # Retrieve and verify
+    query_result = session.query("SELECT mixed_list FROM cassandra_c_test.list_types WHERE id = 'mixed_test'")
+    row = query_result.to_a.first
+    retrieved_array = row[0]
+
+    assert_instance_of Array, retrieved_array
+    assert_equal ["string", "42", "3.14", "true", "false"], retrieved_array
+  end
+
+  def test_array_database_empty_array
+    # Insert an empty array
+    empty_array = []
+
+    statement = CassandraC::Native::Statement.new("INSERT INTO cassandra_c_test.list_types (id, string_list) VALUES (?, ?)", 2)
+    statement.bind_by_index(0, "empty_test")
+    statement.bind_by_index(1, empty_array)
+
+    result = session.execute(statement)
+    assert_instance_of CassandraC::Native::Result, result
+
+    # Retrieve and verify - Cassandra may store empty collections as NULL
+    query_result = session.query("SELECT string_list FROM cassandra_c_test.list_types WHERE id = 'empty_test'")
+    row = query_result.to_a.first
+    retrieved_array = row[0]
+
+    # Empty arrays might be stored as NULL in Cassandra, which is acceptable
+    if retrieved_array.nil?
+      # This is acceptable behavior - empty collections can be NULL in Cassandra
+      assert_nil retrieved_array
+    else
+      # If it's not NULL, it should be an empty Array
+      assert_instance_of Array, retrieved_array
+      assert_equal [], retrieved_array
+      assert retrieved_array.empty?
+    end
+  end
+
+  def test_array_binding_by_name
+    # Test binding by parameter name
+    string_array = ["param", "binding", "test"]
+
+    statement = CassandraC::Native::Statement.new("INSERT INTO cassandra_c_test.list_types (id, string_list) VALUES (:id, :list)", 2)
+    statement.bind_by_name("id", "name_test")
+    statement.bind_by_name("list", string_array)
+
+    result = session.execute(statement)
+    assert_instance_of CassandraC::Native::Result, result
+
+    # Retrieve and verify
+    query_result = session.query("SELECT string_list FROM cassandra_c_test.list_types WHERE id = 'name_test'")
+    row = query_result.to_a.first
+    retrieved_array = row[0]
+
+    assert_instance_of Array, retrieved_array
+    assert_equal ["param", "binding", "test"], retrieved_array
+  end
+
+  def test_array_null_handling
+    # Test null array insertion
+    statement = CassandraC::Native::Statement.new("INSERT INTO cassandra_c_test.list_types (id, string_list) VALUES (?, ?)", 2)
+    statement.bind_by_index(0, "null_test")
+    statement.bind_by_index(1, nil)
+
+    result = session.execute(statement)
+    assert_instance_of CassandraC::Native::Result, result
+
+    # Retrieve and verify
+    query_result = session.query("SELECT string_list FROM cassandra_c_test.list_types WHERE id = 'null_test'")
+    row = query_result.to_a.first
+    retrieved_array = row[0]
+
+    assert_nil retrieved_array
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,7 @@ module TestEnvironment
     session.query("CREATE TABLE IF NOT EXISTS cassandra_c_test.inet_types (id text PRIMARY KEY, ip_address inet, server_ip inet)")
     session.query("CREATE TABLE IF NOT EXISTS cassandra_c_test.decimal_types (id int PRIMARY KEY, float_val float, double_val double, decimal_val decimal)")
     session.query("CREATE TABLE IF NOT EXISTS cassandra_c_test.uuid_types (id text PRIMARY KEY, uuid_val uuid, timeuuid_val timeuuid, created_at timeuuid)")
+    session.query("CREATE TABLE IF NOT EXISTS cassandra_c_test.list_types (id text PRIMARY KEY, string_list list<text>, int_list list<int>, mixed_list list<text>)")
 
     session.close
     @@setup_complete = true


### PR DESCRIPTION
## Summary
- Adds transparent Ruby Array support for Cassandra List collections 
- Arrays automatically bind to list columns with proper type conversion
- Results parse back to plain Ruby Arrays - no wrapper classes needed
- Handles empty arrays and NULL values correctly

## Test plan
- [x] All 195 tests pass including 6 new Array collection tests
- [x] String arrays work with list<text> columns
- [x] Integer arrays work with list<int> columns  
- [x] Empty and NULL array handling verified
- [x] Both index and name binding tested
- [x] Linting passes with bundle exec rake standard

🤖 Generated with [Claude Code](https://claude.ai/code)